### PR TITLE
Selectors

### DIFF
--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -107,6 +107,26 @@ impl<T: GASolution> GAPopulation<T>
         self.individual(self.size()-1, GAPopulationSortBasis::Scaled)
     }
 
+    pub fn best_by_raw_score(&self) -> &T
+    {
+        self.individual(0, GAPopulationSortBasis::Raw)
+    }
+
+    pub fn worst_by_raw_score(&self) -> &T
+    {
+        self.individual(self.size()-1, GAPopulationSortBasis::Scaled)
+    }
+
+    pub fn best_by_scaled_score(&self) -> &T
+    {
+        self.individual(0, GAPopulationSortBasis::Raw)
+    }
+
+    pub fn worst_by_scaled_score(&self) -> &T
+    {
+        self.individual(self.size()-1, GAPopulationSortBasis::Scaled)
+    }
+
     pub fn individual(&self, i : usize, sort_basis : GAPopulationSortBasis) -> &T
     {
         // TODO: Check that i makes sense

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -188,22 +188,22 @@ mod tests
 
         {
             let raw_score_selection = GARawScoreBasedSelection;
-            let mut raw_rank_selector = GARankSelector::new(&mut population, &raw_score_selection);
+            let mut raw_rank_selector = GARankSelector::new(&raw_score_selection);
 
-            raw_rank_selector.update();
+            raw_rank_selector.update(&mut population);
 
             // Best Raw score is that of 1st solution.
-            assert_eq!(raw_rank_selector.select(&mut GARandomCtx::new_unseeded(String::from("test_rank_selector_rng"))).score(), f);
+            assert_eq!(raw_rank_selector.select(&population, &mut GARandomCtx::new_unseeded(String::from("test_rank_selector_rng"))).score(), f);
         }
 
         {
             let scaled_score_selection = GAScaledScoreBasedSelection;
-            let mut scaled_rank_selector = GARankSelector::new(&mut population, &scaled_score_selection);
+            let mut scaled_rank_selector = GARankSelector::new(&scaled_score_selection);
 
-            scaled_rank_selector.update();
+            scaled_rank_selector.update(&mut population);
 
             // Best Scaled score is that of 2nd solution (because fitness is inverse of score). Weird. In this case, LowIsBest.
-            assert_eq!(scaled_rank_selector.select(&mut GARandomCtx::new_unseeded(String::from("test_rank_selector_rng"))).fitness(), i_f_m);
+            assert_eq!(scaled_rank_selector.select(&population, &mut GARandomCtx::new_unseeded(String::from("test_rank_selector_rng"))).fitness(), i_f_m);
         }
     }
 
@@ -219,11 +219,11 @@ mod tests
                                    TestSolution { fitness: f_m }],
                               GAPopulationSortOrder::HighIsBest);
 
-        let mut uniform_selector = GAUniformSelector::new(&mut population);
+        let mut uniform_selector = GAUniformSelector::new();
 
-        uniform_selector.update();
+        uniform_selector.update(&mut population);
 
-        let selected_individual = uniform_selector.select(&mut GARandomCtx::new_unseeded(String::from("test_rank_selector_rng")));
+        let selected_individual = uniform_selector.select(&population, &mut GARandomCtx::new_unseeded(String::from("test_rank_selector_rng")));
         assert!(selected_individual.score() == f || selected_individual.score() == f_m);  
     }
 
@@ -251,22 +251,22 @@ mod tests
             let raw_score_selection = GARawScoreBasedSelection;
 
             let mut raw_roulette_wheel_selector 
-              = GARouletteWheelSelector::new(&mut population, &raw_score_selection);
+              = GARouletteWheelSelector::new(&raw_score_selection, population.size());
 
-            raw_roulette_wheel_selector.update();
+            raw_roulette_wheel_selector.update(&mut population);
 
-            raw_roulette_wheel_selector.select(&mut rng_ctx);
+            raw_roulette_wheel_selector.select(&population, &mut rng_ctx);
         }
         
         {
             let scaled_score_selection = GAScaledScoreBasedSelection;
 
             let mut scaled_roulette_wheel_selector 
-              = GARouletteWheelSelector::new(&mut population, &scaled_score_selection);
+              = GARouletteWheelSelector::new(&scaled_score_selection, population.size());
 
-            scaled_roulette_wheel_selector.update();
+            scaled_roulette_wheel_selector.update(&mut population);
 
-            scaled_roulette_wheel_selector.select(&mut rng_ctx);
+            scaled_roulette_wheel_selector.select(&population, &mut rng_ctx);
         }
     }
 
@@ -293,22 +293,22 @@ mod tests
             let raw_score_selection = GARawScoreBasedSelection;
 
             let mut raw_tournament_selector 
-              = GARouletteWheelSelector::new(&mut population, &raw_score_selection);
+              = GARouletteWheelSelector::new(&raw_score_selection, population.size());
 
-            raw_tournament_selector.update();
+            raw_tournament_selector.update(&mut population);
 
-            raw_tournament_selector.select(&mut rng_ctx);
+            raw_tournament_selector.select(&population, &mut rng_ctx);
         }
 
         {
             let scaled_score_selection = GAScaledScoreBasedSelection;
 
             let mut scaled_tournament_selector 
-              = GARouletteWheelSelector::new(&mut population, &scaled_score_selection);
+              = GARouletteWheelSelector::new(&scaled_score_selection, population.size());
 
-            scaled_tournament_selector.update();
+            scaled_tournament_selector.update(&mut population);
 
-            scaled_tournament_selector.select(&mut rng_ctx);
+            scaled_tournament_selector.select(&population, &mut rng_ctx);
         }
     }
 


### PR DESCRIPTION
Selectors can now be used for benchmarking.

Changes:

- Merged with branch fix_test_failures.

- GAScoreTypeBasedSelection.{max,min}\_score() don't provide default implementations anymore. Instead, the structs that implement the trait (GARawScoreBasedSelection, GAScaledScoreBasedSelection) implement those functions using the new GAPopulation.{best,worst}\_by\_{raw,scaled}_score() functions. This is so that GAScoreTypeBasedSelection objects remain ignorant of the sorted lists of GAPopulation (otherwise, they would need to know that the individual at position 0 is the best one).

- Added rather detailed documentation to some structs and traits, but stopped doing so because I was not using the language consistently. I need to read more / study the theory.

- Updated the tests to reflect these changes.

TODO:

- Use the new RNGs to improve the tests.

- There are some terms that we use interchangeably: Solution and individual; scaled score and fitness. I would like us to choose one of the terms for each and stick with them.

- I don't like much the use of GAPopulation.individual(\<index\>, \<sort_basis\>) in selector code for 2 reasons: 1) We agreed that passing enums to functions to choose among things was bad style. 2) Selector code (except GAScoreTypeBasedSelection) has too much knowledge about GAPopulation when it comes to accessing individuals: It knows that the best individual is at 0 and the worst at n-1. I think we should implement iterators for GAPopulation, one for traversing from best-to-worst raw score, one for best-to-worst scaled score. For selecting individuals, to implement GARankSelector.select(), we would implement a function in GAPopulation that would return a slice of the individuals' array of individuals with score X; GARankSelector.select() would then pass X=best-score and would choose at random from the slice. To implement GAUniformSelector.select(), we could implement a GAPopulation method that would return a slice spanning the whole individuals' array, explicitly stating that no order should be assumed; GAUniformSelector.select() would then choose at random from the slice.