### PR TITLE
Iterable populations

### DIFF
--- a/src/ga/ga_core.rs
+++ b/src/ga/ga_core.rs
@@ -43,7 +43,6 @@ pub trait GASolution
     fn new(f:f32) -> Self;
 
     // Instance
-    fn clone(&self) -> Self;
     fn crossover(&self, other : &Self) -> Self;
     fn mutate(&mut self, pMutation : f32);
     fn evaluate(&mut self) -> f32;

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -203,6 +203,54 @@ impl<T: GASolution> GAPopulation<T>
     }
 }
 
+struct GAPopulationRawIterator<'a, T: 'a + GASolution>
+{
+    population: &'a GAPopulation<T>,
+    next_index: usize
+}
+
+impl<'a, T: 'a + GASolution> Iterator for GAPopulationRawIterator<'a, T>
+{
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item>
+    {
+        if self.next_index == self.population.size()
+        {
+            None
+        }
+        else
+        {
+            self.next_index = self.next_index + 1;
+            Some(self.population.individual(self.next_index - 1, GAPopulationSortBasis::Raw)) 
+        }
+    }
+}
+
+struct GAPopulationFitnessIterator<'a, T: 'a + GASolution>
+{
+    population: &'a GAPopulation<T>,
+    next_index: usize
+}
+
+impl<'a, T: 'a + GASolution> Iterator for GAPopulationFitnessIterator<'a, T>
+{
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item>
+    {
+        if self.next_index == self.population.size()
+        {
+            None
+        }
+        else
+        {
+            self.next_index = self.next_index + 1;
+            Some(self.population.individual(self.next_index - 1, GAPopulationSortBasis::Scaled)) 
+        }
+    }
+
+}
 
 #[cfg(test)]
 mod test

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -220,7 +220,7 @@ pub struct GAPopulationRawIterator<'a, T: 'a + GASolution>
     next: usize
 }
 
-impl<'a, T: 'a + GASolution> Iterator for GAPopulationRawIterator<'a, T>
+impl<'a, T: GASolution> Iterator for GAPopulationRawIterator<'a, T>
 {
     type Item = &'a T;
 
@@ -244,7 +244,7 @@ pub struct GAPopulationFitnessIterator<'a, T: 'a + GASolution>
     next: usize
 }
 
-impl<'a, T: 'a + GASolution> Iterator for GAPopulationFitnessIterator<'a, T>
+impl<'a, T: GASolution> Iterator for GAPopulationFitnessIterator<'a, T>
 {
     type Item = &'a T;
 

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -201,6 +201,16 @@ impl<T: GASolution> GAPopulation<T>
                 },
         };
     }
+
+    pub fn raw_score_iterator() -> GAPopulationRawIterator<T>
+    {
+
+    }
+
+    pub fn fitness_score_iterator() -> GAPopulationFitnessIterator<T>
+    {
+
+    }
 }
 
 struct GAPopulationRawIterator<'a, T: 'a + GASolution>

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -202,21 +202,21 @@ impl<T: GASolution> GAPopulation<T>
         };
     }
 
-    pub fn raw_score_iterator() -> GAPopulationRawIterator<T>
+    pub fn raw_score_iterator<'a>(&'a self) -> GAPopulationRawIterator<'a, T>
     {
-
+        GAPopulationRawIterator { population: &self, next: 0 }
     }
 
-    pub fn fitness_score_iterator() -> GAPopulationFitnessIterator<T>
+    pub fn fitness_score_iterator<'a>(&'a self) -> GAPopulationFitnessIterator<'a, T>
     {
-
+        GAPopulationFitnessIterator { population: &self, next: 0 }
     }
 }
 
-struct GAPopulationRawIterator<'a, T: 'a + GASolution>
+pub struct GAPopulationRawIterator<'a, T: 'a + GASolution>
 {
     population: &'a GAPopulation<T>,
-    next_index: usize
+    next: usize
 }
 
 impl<'a, T: 'a + GASolution> Iterator for GAPopulationRawIterator<'a, T>
@@ -225,22 +225,22 @@ impl<'a, T: 'a + GASolution> Iterator for GAPopulationRawIterator<'a, T>
 
     fn next(&mut self) -> Option<Self::Item>
     {
-        if self.next_index == self.population.size()
+        if self.next == self.population.size()
         {
             None
         }
         else
         {
-            self.next_index = self.next_index + 1;
-            Some(self.population.individual(self.next_index - 1, GAPopulationSortBasis::Raw)) 
+            self.next = self.next + 1;
+            Some(self.population.individual(self.next - 1, GAPopulationSortBasis::Raw)) 
         }
     }
 }
 
-struct GAPopulationFitnessIterator<'a, T: 'a + GASolution>
+pub struct GAPopulationFitnessIterator<'a, T: 'a + GASolution>
 {
     population: &'a GAPopulation<T>,
-    next_index: usize
+    next: usize
 }
 
 impl<'a, T: 'a + GASolution> Iterator for GAPopulationFitnessIterator<'a, T>
@@ -249,14 +249,14 @@ impl<'a, T: 'a + GASolution> Iterator for GAPopulationFitnessIterator<'a, T>
 
     fn next(&mut self) -> Option<Self::Item>
     {
-        if self.next_index == self.population.size()
+        if self.next == self.population.size()
         {
             None
         }
         else
         {
-            self.next_index = self.next_index + 1;
-            Some(self.population.individual(self.next_index - 1, GAPopulationSortBasis::Scaled)) 
+            self.next = self.next + 1;
+            Some(self.population.individual(self.next - 1, GAPopulationSortBasis::Scaled)) 
         }
     }
 

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -292,5 +292,80 @@ mod test
         ga_test_teardown();
     }
 
-    
+    #[test]
+    fn test_population_raw_iterator()
+    {
+        // Iteration of a LowIsBest population yields a sequence of non-decreasing raw scores.
+
+        let mut expected_seq: Vec<f32> = (1..10).map(|rs| rs as f32).collect();
+        {
+            let mut inds: Vec<GATestSolution> = Vec::new();
+            for rs in 1..10
+            {
+                inds.push(GATestSolution::new(rs as f32)); 
+            }
+            let mut pop = GAPopulation::new(inds, GAPopulationSortOrder::LowIsBest);
+            pop.sort();
+
+            let it = pop.raw_score_iterator();
+            let actual_seq: Vec<f32> = it.map(|ind| { ind.score() }).collect();
+            assert_eq!(expected_seq, actual_seq);
+        }
+
+        // Iteration of a HighIsBest population yields a sequence of non-increasing raw scores.
+
+        expected_seq.reverse();
+        {
+            let mut inds: Vec<GATestSolution> = Vec::new();
+            for rs in 1..10
+            {
+                inds.push(GATestSolution::new(rs as f32)); 
+            }
+            let mut pop = GAPopulation::new(inds, GAPopulationSortOrder::HighIsBest);
+            pop.sort();
+
+            let it = pop.raw_score_iterator();
+            let actual_seq: Vec<f32> = it.map(|ind| { ind.score() }).collect();
+            assert_eq!(expected_seq, actual_seq);
+        }
+    }
+
+    #[test]
+    fn test_population_fitness_iterator()
+    {
+        // Iteration of a HighIsBest population yields a sequence of non-decreasing fitness scores (when fitness = 1/raw).
+
+        let mut expected_seq: Vec<f32> = (1..10).map(|rs| 1.0/(rs as f32)).collect();
+        {
+            let mut inds: Vec<GATestSolution> = Vec::new();
+            for rs in 1..10
+            {
+                inds.push(GATestSolution::new(rs as f32)); 
+            }
+            let mut pop = GAPopulation::new(inds, GAPopulationSortOrder::HighIsBest);
+            pop.sort();
+
+            let it = pop.fitness_score_iterator();
+            let actual_seq: Vec<f32> = it.map(|ind| { ind.fitness() }).collect();
+            assert_eq!(expected_seq, actual_seq);
+        }
+
+        // Iteration of a LowIsBest population yields a sequence of non-increasing fitness scores (when fitness = 1/raw).
+
+        expected_seq.reverse();
+        {
+            let mut inds: Vec<GATestSolution> = Vec::new();
+            for rs in 1..10
+            {
+                inds.push(GATestSolution::new(rs as f32)); 
+            }
+            let mut pop = GAPopulation::new(inds, GAPopulationSortOrder::LowIsBest);
+            pop.sort();
+
+            let it = pop.fitness_score_iterator();
+            let actual_seq: Vec<f32> = it.map(|ind| { ind.fitness() }).collect();
+            assert_eq!(expected_seq, actual_seq);
+        }
+
+    }
 }

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -122,7 +122,7 @@ impl<T: GASolution> GAPopulation<T>
 
     pub fn best_by_scaled_score(&self) -> &T
     {
-        self.individual(0, GAPopulationSortBasis::Raw)
+        self.individual(0, GAPopulationSortBasis::Scaled)
     }
 
     pub fn worst_by_scaled_score(&self) -> &T

--- a/src/ga/ga_scaling.rs
+++ b/src/ga/ga_scaling.rs
@@ -117,7 +117,7 @@ mod test
         let mut population = GAPopulation::new(vec![GATestSolution::new(f)], GAPopulationSortOrder::HighIsBest);
         population.sort();
 
-        let scaler = GANoScaling{};
+        let scaler = GANoScaling;
 
         scaler.evaluate(&mut population);
 

--- a/src/ga/ga_selectors.rs
+++ b/src/ga/ga_selectors.rs
@@ -167,11 +167,11 @@ impl<T: GASolution> GASelector<T> for GARankSelector
     }
 }
 
-pub struct GAUniformSelector;
-
 /// Uniform selector.
 ///
 /// Select an individual at random, with equal probability.
+pub struct GAUniformSelector;
+
 impl GAUniformSelector
 {
     pub fn new() -> GAUniformSelector
@@ -201,6 +201,10 @@ impl<T: GASolution> GASelector<T> for GAUniformSelector
 }
 
 /// Roulette Wheel selector.
+///
+/// Select an individual at random, each one having a probability of selection
+/// that is proportional to its score according to ranking (LowIsBest or 
+/// HighIsBest). 
 pub struct GARouletteWheelSelector
 {
     wheel_proportions: Vec<f32>,
@@ -210,10 +214,6 @@ impl GARouletteWheelSelector
 {
     pub fn new(p_size: usize) -> GARouletteWheelSelector
     {
-        // TODO: Comment doesn't look correct.
-        // vec![] borrows references (invocation of size() is through *p, or so the
-        // compiler says); since p has already been borrowed as a mutable reference
-        // (no data races allowed), p.size() can't be passed to vec![].
         let wheel_size = p_size;
 
         GARouletteWheelSelector
@@ -374,6 +374,7 @@ impl<T: GASolution> GASelector<T> for GATournamentSelector
         let individual1;
         let individual2;
 
+        // Select 2 individuals using Roulette Wheel selection.
         individual1 = self.roulette_wheel_selector.select::<S>(pop, rng_ctx);
         individual2 = self.roulette_wheel_selector.select::<S>(pop, rng_ctx);
 
@@ -389,6 +390,7 @@ impl<T: GASolution> GASelector<T> for GATournamentSelector
             high_score_individual = individual2;
         }
 
+        // Return the individual that is best according to population rank.
         match pop.order()
         {
             GAPopulationSortOrder::HighIsBest => high_score_individual,

--- a/src/ga/ga_simple.rs
+++ b/src/ga/ga_simple.rs
@@ -110,7 +110,7 @@ impl<T: GASolution> SimpleGeneticAlgorithm<T>
         SimpleGeneticAlgorithm { current_generation: 0, config : cfg, population : p, rng_ctx : GARandomCtx::from_seed(cfg.d_seed, String::from("")) }
     }
 }
-impl<T: GASolution> GeneticAlgorithm<T> for SimpleGeneticAlgorithm <T>
+impl<T: GASolution + Clone> GeneticAlgorithm<T> for SimpleGeneticAlgorithm <T>
 {
     fn config(&mut self) -> &GAConfig
     {

--- a/src/ga/ga_test.rs
+++ b/src/ga/ga_test.rs
@@ -51,7 +51,7 @@ impl GASolution for GATestSolution
         GATestSolution{ fitness: f}
     }
 
-    fn clone(&self) -> Self { GATestSolution::new(self.fitness) }
+    //fn clone(&self) -> Self { GATestSolution::new(self.fitness) }
     fn evaluate(&mut self) -> f32 { self.fitness }
 #[allow(unused_variables)]
     fn crossover(&self, other : &Self) -> Self { GATestSolution::new(self.fitness) }

--- a/src/ga/ga_test.rs
+++ b/src/ga/ga_test.rs
@@ -44,6 +44,7 @@ pub fn ga_test_teardown(){}
 
 /// GATestSolution
 /// Implements the GASolution Trait with only no-ops
+#[derive(Clone)]
 pub struct GATestSolution
 {
     score: f32,


### PR DESCRIPTION
Implement iterators for iterating over populations in Raw score order and Scaled score order. This is to avoid calling GAPopulation::individual() from client code (such as selector code), which exposes the implementation.

GAPopulationRawIterator and GAPopulationFitness iterator implement the Iterator trait and borrow the population they iterate over. They are meant to be built by the borrowed population, using GAPopulation::raw_score_iterator() and GAPopulation::fitness_score_iterator().

Selector code needed a major redesign of its traits and structs. The highlights are:

- Renamed GAScoreTypeBasedSelection -> GAScoreSelection (shorter).

- Use GAScoreSelection trait methods statically. Implementors are no longer receivers of the methods. This eliminates the need for trait objects owned or borrowed by GASelectors and the complexities entailed by their lifetimes. Instead, the GASelector trait methods are parameterized with the type of GAScoreSelection to be used (client code gets a little more complicated, they need to do `update<GARawScoreSelection>()`, `select<GARawScoreSelection>`, so they need to keep those 2 calls in sync).

- GAScoreSelection::iterator() returns the iterator that corresponds to its score type; concrete iterator implementation types are not returned, so that they can be used polymorphically. A Box<Iterator> is returned, because the size of a return value needs to be known at compile time; since Iterator is a trait and not a concrete type, it cannot be the return type. A &Iterator cannot be returned either, because ownership of the concrete iterator would have been needed to be given to the structs implementing GAScoreSelection, and we had decided to use those objects statically (if that's the proper term).

- The Box will own the memory of the concrete iterator. The default 'static lifetime of the box contents is overriden by a lifetime of the borrowed populations's GASolutions (the iterator borrows the input population).

**TODOs**

- [x] Iterator usage in GARankSelector is just a demo; usage should be more idiomatic, i.e. with closures, adaptors, etc.

- [ ] Only GARankSelector uses the iterators currently. Next commit should incorporate to all selectors.

- [x] The test_rank_selector test doesn't pass :D

@Sysnett 