### PR TITLE
Cleanup for cargo push

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-monster"
 version = "0.1.0"
 authors = ["El Jacko <eljacko@revolutionsolid.com>", "Ricardo Sisnett <sysnet@revolutionsolid.com>"]
 
-description = "GALib Rust port"
+description = "GALib rust port"
 license = "MIT"
 homepage = "https://www.github.com/mrjackinc/rust-monster"
 

--- a/src/ga/ga_core.rs
+++ b/src/ga/ga_core.rs
@@ -6,7 +6,7 @@
 //! Defines the core traits to work with rust-monster
 
 
-use super::ga_population::{GAPopulation, GAPopulationSortOrder};
+use ::ga::ga_population::{GAPopulation, GAPopulationSortOrder};
 
 /// Bit Flags for Genetic Algorithm Configuration 
 /// 
@@ -23,27 +23,11 @@ impl Default for GAFlags
     fn default() -> GAFlags { GAFlags {bits : 0} }
 }
 
-
-/// Genetic Algorithm Configuration
-///
-/// 
-pub trait GAConfig
-{
-    fn flags(&self) -> GAFlags;
-    fn max_generations(&self) -> i32;
-    fn probability_crossover(&self) -> f32;
-    fn probability_mutation(&self) -> f32;
-}
-
-
 /// Genetic Algorithm Solution
 pub trait GASolution
 {
-    //Static
-    fn new(f:f32) -> Self;
-
     // Instance
-    fn crossover(&self, other : &Self) -> Self;
+    fn crossover(&self, other : &Self) -> Box<Self>;
     fn mutate(&mut self, pMutation : f32);
     fn evaluate(&mut self) -> f32;
     // Scaled fitness score
@@ -87,8 +71,6 @@ pub trait GeneticAlgorithm<T: GASolution>
     }
 
     // IMPLEMENTATION SPECIFIC
-    fn config(&mut self) -> &GAConfig;
-
     fn population(&mut self) -> &mut GAPopulation<T>;
 
     fn initialize_internal(&mut self) {}

--- a/src/ga/ga_population.rs
+++ b/src/ga/ga_population.rs
@@ -4,7 +4,7 @@
 
 //! Genetic Algorithm Population
 
-use super::ga_core::GASolution;
+use ::ga::ga_core::GASolution;
 
 use std::cmp::Ordering;
 use std::iter::FromIterator;
@@ -269,8 +269,8 @@ impl<'a, T: GASolution> Iterator for GAPopulationFitnessIterator<'a, T>
 mod test
 {
     use super::*;
-    use super::super::ga_test::*;
-    use super::super::ga_core::*;
+    use ::ga::ga_test::*;
+    use ::ga::ga_core::*;
 
     #[test]
     fn test_sort_population()
@@ -295,6 +295,7 @@ mod test
     #[test]
     fn test_population_raw_iterator()
     {
+        ga_test_setup("ga_population::test_population_raw_iterator");
         // Iteration of a LowIsBest population yields a sequence of non-decreasing raw scores.
 
         let mut expected_seq: Vec<f32> = (1..10).map(|rs| rs as f32).collect();
@@ -328,11 +329,13 @@ mod test
             let actual_seq: Vec<f32> = it.map(|ind| { ind.score() }).collect();
             assert_eq!(expected_seq, actual_seq);
         }
+        ga_test_teardown()
     }
 
     #[test]
     fn test_population_fitness_iterator()
     {
+        ga_test_setup("ga_population::test_population_fitness_iterator");
         // Iteration of a HighIsBest population yields a sequence of non-decreasing fitness scores (when fitness = 1/raw).
 
         let mut expected_seq: Vec<f32> = (1..10).map(|rs| 1.0/(rs as f32)).collect();
@@ -366,6 +369,6 @@ mod test
             let actual_seq: Vec<f32> = it.map(|ind| { ind.fitness() }).collect();
             assert_eq!(expected_seq, actual_seq);
         }
-
+        ga_test_teardown();
     }
 }

--- a/src/ga/ga_random.rs
+++ b/src/ga/ga_random.rs
@@ -148,7 +148,7 @@ impl fmt::Debug for GARandomCtx
 mod test
 {
     use super::{GASeed, GARandomCtx};
-    use super::super::ga_test::{ga_test_setup, ga_test_teardown};
+    use ::ga::ga_test::{ga_test_setup, ga_test_teardown};
 
     #[test]
     fn same_seed()

--- a/src/ga/ga_scaling.rs
+++ b/src/ga/ga_scaling.rs
@@ -6,8 +6,8 @@
 //!
 //! Scales the raw score of a Population's individuals.
 
-use super::ga_core::GASolution;
-use super::ga_population::GAPopulation;
+use ::ga::ga_core::GASolution;
+use ::ga::ga_population::GAPopulation;
 
 /// Scaling Scheme Trait
 /// 

--- a/src/ga/ga_selectors.rs
+++ b/src/ga/ga_selectors.rs
@@ -25,9 +25,9 @@
 //! `GATournamentSelector`
 //!
 //! # Examples
-use super::ga_core::GASolution;
-use super::ga_population::{GAPopulation, GAPopulationSortBasis, GAPopulationSortOrder};
-use super::ga_random::{GARandomCtx};
+use ::ga::ga_core::GASolution;
+use ::ga::ga_population::{GAPopulation, GAPopulationSortBasis, GAPopulationSortOrder};
+use ::ga::ga_random::{GARandomCtx};
 use std::cmp;
 
 /// Selector trait.
@@ -405,10 +405,11 @@ impl<T: GASolution> GASelector<T> for GATournamentSelector
 #[cfg(test)]
 mod test
 {
-    use super::super::ga_core::*;
-    use super::super::ga_population::*;
-    use super::super::ga_random::*;
-    use super::super::ga_test::*;
+    use ::ga::ga_core::*;
+    use ::ga::ga_population::*;
+    use ::ga::ga_random::*;
+    use ::ga::ga_test::*;
+
     use super::*;
 
     #[test]

--- a/src/ga/ga_simple.rs
+++ b/src/ga/ga_simple.rs
@@ -1,9 +1,9 @@
 // Copyright 2016 Revolution Solid & Contributors.
 // author(s): sysnett
 // rust-monster is licensed under a MIT License.
-use super::ga_core::{GAConfig, GAFactory, GAFlags, GeneticAlgorithm, GASolution};
-use super::ga_population::GAPopulation;
-use super::ga_random::{GARandomCtx, GASeed};
+use ::ga::ga_core::{GAFactory, GAFlags, GeneticAlgorithm, GASolution};
+use ::ga::ga_population::GAPopulation;
+use ::ga::ga_random::{GARandomCtx, GASeed};
 
 /// Simple Genetic Algorithm Config
 /// Genetic Algorithm Config Trait Implementation for the Simple Genetic Algorithm
@@ -13,41 +13,11 @@ pub struct SimpleGeneticAlgorithmCfg
     pub d_seed : GASeed,
     pub pconv  : f32,
     pub is_min : bool,
-
-    // GAConfig Trait
     pub max_generations         : i32, 
     pub flags                   : GAFlags, 
     pub probability_crossover   : f32,
     pub probability_mutation    : f32,
-
-    // Simple GA
     pub elitism : bool,
-}
-impl GAConfig for SimpleGeneticAlgorithmCfg
-{
-    fn flags(&self) -> GAFlags
-    {
-        self.flags
-    }
-    fn max_generations(&self) -> i32
-    {
-        self.max_generations
-    }
-    fn probability_crossover(&self) -> f32
-    {
-        self.probability_crossover
-    }
-    fn probability_mutation(&self) -> f32
-    {
-        self.probability_mutation 
-    }
-}
-impl SimpleGeneticAlgorithmCfg
-{
-    fn elitism(&self) -> bool
-    {
-        self.elitism
-    }
 }
 
 /// Simple Genetic Algorithm 
@@ -57,19 +27,6 @@ impl SimpleGeneticAlgorithmCfg
 /// This genetic algorithm is the 'simple' genetic algorithm that Goldberg describes 
 /// in his book. It uses non-overlapping populations. When you create a simple genetic 
 /// algorithm, you must specify either an individual or a population of individuals. 
-/// The new genetic algorithm will clone the individual(s) that you specify to make 
-/// its own population. You can change most of the genetic algorithm behaviors after 
-/// creation and during the course of the evolution.
-///
-/// The simple genetic algorithm creates an initial population by cloning the individual 
-/// or population you pass when you create it. Each generation the algorithm creates 
-/// an entirely new population of individuals by selecting from the previous population 
-/// then mating to produce the new offspring for the new population. This process continues 
-/// until the stopping criteria are met (determined by the terminator).
-///
-/// Elitism is optional. By default, elitism is on, meaning that the best individual 
-/// from each generation is carried over to the next generation.
-///
 pub struct SimpleGeneticAlgorithm<T: GASolution>
 {
   current_generation : i32, 
@@ -79,8 +36,6 @@ pub struct SimpleGeneticAlgorithm<T: GASolution>
 }
 impl<T: GASolution> SimpleGeneticAlgorithm<T>
 {
-    // TODO: Document this -new- pattern and others from the
-    // pattern GitHub
     pub fn new(cfg: SimpleGeneticAlgorithmCfg,
                factory: Option<&mut GAFactory<T>>,
                population: Option<GAPopulation<T>>) -> SimpleGeneticAlgorithm<T>
@@ -112,11 +67,6 @@ impl<T: GASolution> SimpleGeneticAlgorithm<T>
 }
 impl<T: GASolution + Clone> GeneticAlgorithm<T> for SimpleGeneticAlgorithm <T>
 {
-    fn config(&mut self) -> &GAConfig
-    {
-        &self.config
-    }
-
     fn population(&mut self) -> &mut GAPopulation<T>
     {
         &mut self.population
@@ -137,25 +87,25 @@ impl<T: GASolution + Clone> GeneticAlgorithm<T> for SimpleGeneticAlgorithm <T>
         {
             let ind = self.population.select();
             let mut new_ind = ind.clone();
-            if self.rng_ctx.test_value(self.config.probability_crossover())
+            if self.rng_ctx.test_value(self.config.probability_crossover)
             {
                 let ind_2 = self.population.select();
-                new_ind = ind.crossover(ind_2);
+                new_ind = *ind.crossover(ind_2);
             }
 
-            new_ind.mutate(self.config.probability_mutation());
+            new_ind.mutate(self.config.probability_mutation);
 
             new_individuals.push(new_ind);
         }
 
         // Evaluate the new population
-//        self.population.swap(new_individuals);
+        // self.population.swap(new_individuals);
         self.population.evaluate();
         self.population.sort();
 
         let best_old_individual = self.population.best().clone();
 
-        if self.config.elitism()
+        if self.config.elitism
         {
             if best_old_individual.fitness() > self.population.worst().fitness()
             {
@@ -169,7 +119,7 @@ impl<T: GASolution + Clone> GeneticAlgorithm<T> for SimpleGeneticAlgorithm <T>
 
     fn done_internal(&mut self) -> bool
     {
-        self.current_generation >= self.config().max_generations() 
+        self.current_generation >= self.config.max_generations 
     }
 }
 
@@ -178,9 +128,9 @@ impl<T: GASolution + Clone> GeneticAlgorithm<T> for SimpleGeneticAlgorithm <T>
 #[cfg(test)]
 mod tests
 {
-    use super::super::ga_test::*;
-    use super::super::ga_population::*;
-    use super::super::ga_core::*;
+    use ::ga::ga_test::*;
+    use ::ga::ga_population::*;
+    use ::ga::ga_core::*;
     use super::*;
 
     fn simple_ga_validation(sga:&mut SimpleGeneticAlgorithm<GATestSolution>)

--- a/src/ga/ga_test.rs
+++ b/src/ga/ga_test.rs
@@ -5,8 +5,8 @@
 //! GA Test Utilities
 //! Reusable classes for testing
 
-use super::ga_core::*;
-use super::ga_population::*;
+use ::ga::ga_core::*;
+use ::ga::ga_population::*;
 
 #[cfg(test)]
 extern crate env_logger;
@@ -50,15 +50,21 @@ pub struct GATestSolution
     score: f32,
     fitness: f32
 }
-impl GASolution for GATestSolution 
+impl GATestSolution
 {
-    fn new(rs:f32) -> GATestSolution
+    pub fn new(rs:f32) -> GATestSolution
     {
         GATestSolution{ score: rs, fitness: 1.0/rs }
     }
-
+}
+impl GASolution for GATestSolution 
+{
+   // fn clone(&self) -> Self { GATestSolution::new(self.score) }
     fn evaluate(&mut self) -> f32 { self.fitness }
-    fn crossover(&self, _: &Self) -> Self { GATestSolution::new(self.fitness) }
+    fn crossover(&self, _: &GATestSolution) -> Box<GATestSolution>
+    { 
+        Box::new(GATestSolution::new(self.fitness))
+    }
     fn mutate(&mut self, _: f32) {}
     fn fitness(&self) -> f32 { self.fitness }
     fn set_fitness(&mut self, fitness:f32) { self.fitness = fitness; }


### PR DESCRIPTION
Mainly cleans:
super::mod for ::mod    (Let's make this the standard)
GAIndividual is now a Trait Object (Let's keep it that way)